### PR TITLE
noice-nvim disable lsp signature of that plugin - fix warning

### DIFF
--- a/lua/astrocommunity/utility/noice-nvim/init.lua
+++ b/lua/astrocommunity/utility/noice-nvim/init.lua
@@ -22,6 +22,10 @@ return {
           ["vim.lsp.util.stylize_markdown"] = true,
           ["cmp.entry.get_documentation"] = true,
         },
+
+        signature = {
+          enabled = false,
+        },
       },
       presets = {
         bottom_search = true, -- use a classic bottom cmdline for search


### PR DESCRIPTION
I got a warning when I was opening my nvim.
I disable the signature and the warning is gone and I see no difference.

Here the warning
<img width="1341" alt="image" src="https://github.com/t1gu1/astrocommunity/assets/12479055/0b9501e4-fab2-46a4-8a35-d4a7bfce1536">
